### PR TITLE
endre slik at fetchmock ikke evalueres som del av require

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -41,6 +41,7 @@ if (isMockApp || environment.MILJO === 'dev-sbs' ) {
 }
 if ( environment.MILJO === 'labs-gcp') {
     require('./mock/enhetsRegisteretMock').mock();
+    require('./mock/altinnMock').mock();
     require('./mock/altinnMeldingsboksMock').mock();
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -28,20 +28,20 @@ if (isMockApp) {
     console.log('=============== MED MOCK ===============');
     console.log('== DETTE SKAL DU IKKE SE I PRODUKSJON ==');
     console.log('========================================');
-    require('./mock/pamMock');
-    require('./mock/syfoMock');
-    require('./mock/altinnMock');
-    require('./mock/altinnMeldingsboksMock');
-    require('./mock/unleashMock');
-    require('./mock/altinnBeOmTilgangMock')
+    require('./mock/pamMock').mock();
+    require('./mock/syfoMock').mock();
+    require('./mock/altinnMock').mock();
+    require('./mock/altinnMeldingsboksMock').mock();
+    require('./mock/unleashMock').mock();
+    require('./mock/altinnBeOmTilgangMock').mock();
 }
 
 if (isMockApp || environment.MILJO === 'dev-sbs' ) {
-    require('./mock/enhetsRegisteretMock');
+    require('./mock/enhetsRegisteretMock').mock();
 }
 if ( environment.MILJO === 'labs-gcp') {
-    require('./mock/enhetsRegisteretMock');
-    require('./mock/altinnMeldingsboksMock');
+    require('./mock/enhetsRegisteretMock').mock();
+    require('./mock/altinnMeldingsboksMock').mock();
 }
 
 ReactDOM.render(<App />, document.getElementById('root'));

--- a/src/mock/altinnBeOmTilgangMock.ts
+++ b/src/mock/altinnBeOmTilgangMock.ts
@@ -32,7 +32,8 @@ const søknader: AltinnTilgangssøknad[] = [
     }
 ]
 
-fetchMock.get('/min-side-arbeidsgiver/api/altinn-tilgangssoknad', () => søknader);
+export const mock = () => {
+    fetchMock.get('/min-side-arbeidsgiver/api/altinn-tilgangssoknad', () => søknader);
 
 // fetchMock.post('/min-side-arbeidsgiver/api/altinn-tilgangssoknad', (url, request) => {
 //     const skjema = JSON.parse(request.body?.toString() ?? '') as AltinnTilgangssøknadskjemaDTO;
@@ -50,3 +51,5 @@ fetchMock.get('/min-side-arbeidsgiver/api/altinn-tilgangssoknad', () => søknade
 //     id += 1;
 //     return søknad;
 // });
+
+}

--- a/src/mock/altinnMeldingsboksMock.ts
+++ b/src/mock/altinnMeldingsboksMock.ts
@@ -103,6 +103,8 @@ const getMessagesForReportee = (url: string): any => {
     return {};
 };
 
-fetchMock.get(`${altinnUrl}/api/reportees`, reportees);
+export const mock = () => {
+    fetchMock.get(`${altinnUrl}/api/reportees`, reportees);
 
-fetchMock.get(`glob:${altinnUrl}/api/*/messages*`, getMessagesForReportee);
+    fetchMock.get(`glob:${altinnUrl}/api/*/messages*`, getMessagesForReportee);
+}

--- a/src/mock/altinnMock.ts
+++ b/src/mock/altinnMock.ts
@@ -1,15 +1,6 @@
 import fetchMock from 'fetch-mock';
 const delay = new Promise(res => setTimeout(res, 500));
 
-fetchMock
-    .get(
-        'min-side-arbeidsgiver/api/organisasjoner',
-        delay.then(() => {
-            return OrganisasjonerResponse;
-        })
-    )
-    .spy();
-
 export const OrganisasjonerResponse = [
     {
         Name: 'BALLSTAD OG HAMARØY',
@@ -116,33 +107,6 @@ export const OrganisasjonerResponse = [
       }
 ];
 
-fetchMock
-    .get(
-        '/min-side-arbeidsgiver/api/rettigheter-til-skjema/?serviceKode=5216&serviceEdition=1',
-        delay.then(() => {
-            return mentortilskuddskjemaResponse;
-        })
-    )
-    .spy();
-
-fetchMock
-    .get(
-        '/min-side-arbeidsgiver/api/rettigheter-til-skjema/?serviceKode=4936&serviceEdition=1',
-        delay.then(() => {
-            return InntektsmeldingSkjemaResponse;
-        })
-    )
-    .spy();
-
-fetchMock
-    .get(
-        'begin:/min-side-arbeidsgiver/api/rettigheter-til-skjema/',
-        delay.then(() => {
-            return rettigheterSkjemaDefaultResponse;
-        })
-    )
-    .spy();
-
 const organisasjonerMedRettigheter = [
     '811076732',
     '811076112',
@@ -222,3 +186,40 @@ const InntektsmeldingSkjemaResponse = [
     },
 ];
 
+export const mock = () => {
+    fetchMock
+        .get(
+            'min-side-arbeidsgiver/api/organisasjoner',
+            delay.then(() => {
+                return OrganisasjonerResponse;
+            })
+        )
+        .spy();
+
+    fetchMock
+        .get(
+            '/min-side-arbeidsgiver/api/rettigheter-til-skjema/?serviceKode=5216&serviceEdition=1',
+            delay.then(() => {
+                return mentortilskuddskjemaResponse;
+            })
+        )
+        .spy();
+
+    fetchMock
+        .get(
+            '/min-side-arbeidsgiver/api/rettigheter-til-skjema/?serviceKode=4936&serviceEdition=1',
+            delay.then(() => {
+                return InntektsmeldingSkjemaResponse;
+            })
+        )
+        .spy();
+
+    fetchMock
+        .get(
+            'begin:/min-side-arbeidsgiver/api/rettigheter-til-skjema/',
+            delay.then(() => {
+                return rettigheterSkjemaDefaultResponse;
+            })
+        )
+        .spy();
+}

--- a/src/mock/enhetsRegisteretMock.ts
+++ b/src/mock/enhetsRegisteretMock.ts
@@ -1,123 +1,125 @@
 import fetchMock from 'fetch-mock';
 
-fetchMock
-    .get(
-        'begin:https://data.brreg.no/enhetsregisteret/api/underenheter',
+export const mock = () => {
+    fetchMock
+        .get(
+            'begin:https://data.brreg.no/enhetsregisteret/api/underenheter',
 
-        {
-            "organisasjonsnummer": "974491850",
-            "navn": "VIRKSOMHETENS NAVN",
-            "organisasjonsform": {
-                "kode": "BEDR",
-                "beskrivelse": "Bedrift",
+            {
+                "organisasjonsnummer": "974491850",
+                "navn": "VIRKSOMHETENS NAVN",
+                "organisasjonsform": {
+                    "kode": "BEDR",
+                    "beskrivelse": "Bedrift",
+                    "_links": {
+                        "self": {
+                            "href": "https://data.brreg.no/enhetsregisteret/api/organisasjonsformer/BEDR"
+                        }
+                    }
+                },
+                "postadresse": {
+                    "land": "Norge",
+                    "landkode": "NO",
+                    "postnummer": "8003",
+                    "poststed": "BODØ",
+                    "adresse": [
+                        "Evald Erlandsens vei 10"
+                    ],
+                    "kommune": "BODØ",
+                    "kommunenummer": "1804"
+                },
+                "registreringsdatoEnhetsregisteret": "1995-06-15",
+                "registrertIMvaregisteret": false,
+                "naeringskode1": {
+                    "beskrivelse": "Xyz",
+                    "kode": "85.522"
+                },
+                "antallAnsatte": 0,
+                "overordnetEnhet": "982033268",
+                "oppstartsdato": "1995-03-01",
+                "datoEierskifte": "2000-07-01",
+                "beliggenhetsadresse": {
+                    "land": "Norge",
+                    "landkode": "NO",
+                    "postnummer": "1234",
+                    "poststed": "KARDEMOMME BY",
+                    "adresse": [
+                        "Tante Sofies gate 1"
+                    ],
+                    "kommune": "KRISTIANSAND",
+                    "kommunenummer": "1804"
+                },
                 "_links": {
                     "self": {
-                        "href": "https://data.brreg.no/enhetsregisteret/api/organisasjonsformer/BEDR"
+                        "href": "https://data.brreg.no/enhetsregisteret/api/underenheter/974491850"
+                    },
+                    "overordnetEnhet": {
+                        "href": "https://data.brreg.no/enhetsregisteret/api/enheter/982033268"
                     }
                 }
             },
+        )
+        .spy();
+
+    fetchMock
+        .get('begin:https://data.brreg.no/enhetsregisteret/api/enheter', {
+            "organisasjonsnummer": "982033268",
+            "navn": "Navn på overordnet enhet",
+            "organisasjonsform": {
+                "kode": "ENK",
+                "beskrivelse": "Enkeltpersonforetak",
+                "_links": {
+                    "self": {
+                        "href": "https://data.brreg.no/enhetsregisteret/api/organisasjonsformer/ENK"
+                    }
+                }
+            },
+            "hjemmeside": "www.hjemmeside123.no",
             "postadresse": {
                 "land": "Norge",
                 "landkode": "NO",
-                "postnummer": "8003",
-                "poststed": "BODØ",
+                "postnummer": "1234",
+                "poststed": "KRISTIANSAND",
                 "adresse": [
-                    "Evald Erlandsens vei 10"
+                    "Thorbjørn Egners vei 10"
                 ],
                 "kommune": "BODØ",
                 "kommunenummer": "1804"
             },
-            "registreringsdatoEnhetsregisteret": "1995-06-15",
+            "registreringsdatoEnhetsregisteret": "2000-06-02",
             "registrertIMvaregisteret": false,
             "naeringskode1": {
                 "beskrivelse": "Xyz",
                 "kode": "85.522"
             },
             "antallAnsatte": 0,
-            "overordnetEnhet": "982033268",
-            "oppstartsdato": "1995-03-01",
-            "datoEierskifte": "2000-07-01",
-            "beliggenhetsadresse": {
+            "forretningsadresse": {
                 "land": "Norge",
                 "landkode": "NO",
-                "postnummer": "1234",
+                "postnummer": "1324",
                 "poststed": "KARDEMOMME BY",
                 "adresse": [
-                    "Tante Sofies gate 1"
+                    "Røverhuset "
                 ],
-                "kommune": "KRISTIANSAND",
+                "kommune": "BODØ",
                 "kommunenummer": "1804"
             },
+            "institusjonellSektorkode": {
+                "kode": "8200",
+                "beskrivelse": "Personlig næringsdrivende"
+            },
+            "registrertIForetaksregisteret": false,
+            "registrertIStiftelsesregisteret": false,
+            "registrertIFrivillighetsregisteret": false,
+            "konkurs": false,
+            "underAvvikling": false,
+            "underTvangsavviklingEllerTvangsopplosning": false,
+            "maalform": "Bokmål",
             "_links": {
                 "self": {
-                    "href": "https://data.brreg.no/enhetsregisteret/api/underenheter/974491850"
-                },
-                "overordnetEnhet": {
                     "href": "https://data.brreg.no/enhetsregisteret/api/enheter/982033268"
                 }
             }
-        },
-    )
-    .spy();
-
-fetchMock
-    .get('begin:https://data.brreg.no/enhetsregisteret/api/enheter', {
-        "organisasjonsnummer": "982033268",
-        "navn": "Navn på overordnet enhet",
-        "organisasjonsform": {
-            "kode": "ENK",
-            "beskrivelse": "Enkeltpersonforetak",
-            "_links": {
-                "self": {
-                    "href": "https://data.brreg.no/enhetsregisteret/api/organisasjonsformer/ENK"
-                }
-            }
-        },
-        "hjemmeside": "www.hjemmeside123.no",
-        "postadresse": {
-            "land": "Norge",
-            "landkode": "NO",
-            "postnummer": "1234",
-            "poststed": "KRISTIANSAND",
-            "adresse": [
-                "Thorbjørn Egners vei 10"
-            ],
-            "kommune": "BODØ",
-            "kommunenummer": "1804"
-        },
-        "registreringsdatoEnhetsregisteret": "2000-06-02",
-        "registrertIMvaregisteret": false,
-        "naeringskode1": {
-            "beskrivelse": "Xyz",
-            "kode": "85.522"
-        },
-        "antallAnsatte": 0,
-        "forretningsadresse": {
-            "land": "Norge",
-            "landkode": "NO",
-            "postnummer": "1324",
-            "poststed": "KARDEMOMME BY",
-            "adresse": [
-                "Røverhuset "
-            ],
-            "kommune": "BODØ",
-            "kommunenummer": "1804"
-        },
-        "institusjonellSektorkode": {
-            "kode": "8200",
-            "beskrivelse": "Personlig næringsdrivende"
-        },
-        "registrertIForetaksregisteret": false,
-        "registrertIStiftelsesregisteret": false,
-        "registrertIFrivillighetsregisteret": false,
-        "konkurs": false,
-        "underAvvikling": false,
-        "underTvangsavviklingEllerTvangsopplosning": false,
-        "maalform": "Bokmål",
-        "_links": {
-            "self": {
-                "href": "https://data.brreg.no/enhetsregisteret/api/enheter/982033268"
-            }
-        }
-    })
-    .spy();
+        })
+        .spy();
+}

--- a/src/mock/pamMock.ts
+++ b/src/mock/pamMock.ts
@@ -1,15 +1,17 @@
 import fetchMock from 'fetch-mock';
 import { pamSettBedriftLenke, pamHentStillingsannonserLenke } from '../lenker';
 
-fetchMock.get(pamSettBedriftLenke('811076422'), 200);
-fetchMock.get(pamHentStillingsannonserLenke, {
-    TIL_GODKJENNING: 17,
-    GODKJENT: 0,
-    PAABEGYNT: 42,
-    TIL_AVSLUTTING: 0,
-    AVSLUTTET: 5,
-    AVVIST: 0,
-    PUBLISERT: 0,
-});
+export const mock = () => {
+    fetchMock.get(pamSettBedriftLenke('811076422'), 200);
+    fetchMock.get(pamHentStillingsannonserLenke, {
+        TIL_GODKJENNING: 17,
+        GODKJENT: 0,
+        PAABEGYNT: 42,
+        TIL_AVSLUTTING: 0,
+        AVSLUTTET: 5,
+        AVVIST: 0,
+        PUBLISERT: 0,
+    });
 
-fetchMock.get('begin:' + pamSettBedriftLenke(''), 200).spy();
+    fetchMock.get('begin:' + pamSettBedriftLenke(''), 200).spy();
+}

--- a/src/mock/syfoMock.ts
+++ b/src/mock/syfoMock.ts
@@ -3,13 +3,15 @@ import { digiSyfoNarmesteLederLink } from '../lenker';
 
 const delay = new Promise(res => setTimeout(res, 1500));
 
-fetchMock
-    .get(
-        digiSyfoNarmesteLederLink,
-        delay.then(() => {
-            return {
-                tilgang: true,
-            };
-        })
-    )
-    .spy();
+export const mock = () => {
+    fetchMock
+        .get(
+            digiSyfoNarmesteLederLink,
+            delay.then(() => {
+                return {
+                    tilgang: true,
+                };
+            })
+        )
+        .spy();
+}

--- a/src/mock/unleashMock.ts
+++ b/src/mock/unleashMock.ts
@@ -1,5 +1,7 @@
 import fetchMock from 'fetch-mock';
 
-fetchMock.get('/min-side-arbeidsgiver/api/feature?feature=msa.visRefusjon', {
-    "msa.visRefusjon": true
-});
+export const mock = () => {
+    fetchMock.get('/min-side-arbeidsgiver/api/feature?feature=msa.visRefusjon', {
+        "msa.visRefusjon": true
+    });
+}


### PR DESCRIPTION
endre slik at fetchmock ikke evalueres som del av require, men eksplisitt kalles for hver mock.

For å unngå at labs knekker pga dette så har jeg lagt til en linje som eksplisitt mocker altinn. Dette er lik oppførsel som i dag, bare at det ikke skjer som en sideeffekt. Jeg gjorde dette for å unngå breakage da det var forskjell på mocken i frontend og mocken i backend. 

dersom vi tar bort mocking av altinn så må vi også endre backend til å mocke bedriften som fungerer med tiltaksløsningen: https://github.com/navikt/ditt-nav-arbeidsgiver-api/pull/174/files